### PR TITLE
Tsrc dev: developer can now run tests without modifying the script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ Further documentation is forthcoming.
 
 ***Make sure you installed everything here correclty, along with the others subsystems per instructions at https://github.com/turbo-src/turbo-src.***
 
+```
+./tsrc-dev start
+```
+
 Start turbosrc.
 
 ```
@@ -31,10 +35,30 @@ Restart turbosrc.
 ./tsrc-dev restart
 ```
 
-Run tests.
+Run all tests.
 
 ```
-./tsrc-dev test
+./tsrc-dev test <username> <repository> run_tests
+````
+
+Example usage:
+
+```
+./tsrc-dev test 7db9a demo run_tests
+```
+
+The above is all you need but below provides more granular control.
+
+```
+./tsrc-dev test <username> <repository> delete_fork
+````
+
+```
+./tsrc-dev test <username> <repository> fork_repo
+````
+
+```
+./tsrc-dev test <username> <repository> create_pull_request
 ````
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -35,19 +35,33 @@ Restart turbosrc.
 ./tsrc-dev restart
 ```
 
-Run all tests.
+Test.
 
 ```
-./tsrc-dev test <username> <repository> run_tests
+./tsrc-dev test <username> <repository> execute_all
 ````
 
-Example usage:
+Example usage with user "7db9a" and repo "demo". Essentially, just replace your username and keep everything as is for basic usage.
 
 ```
-./tsrc-dev test 7db9a demo run_tests
-```
+./tsrc-dev test 7db9a demo execute_all
+````
 
-The above is all you need but below provides more granular control.
+`username` is your GH personal username name. `repository` is the repo forked from turbo-src for testing.
+
+### More on tests with tsrc-dev
+
+`tsrc-dev test` is a subcommand.
+
+Build test environment and run all tests.
+
+```
+./tsrc-dev test <username> <repository> execute_all
+````
+
+There are various other commands with `tsrc-dev test`. For further usage just enter `tsrc-dev test`.
+
+Here is a sample below for more granular control over testing.
 
 ```
 ./tsrc-dev test <username> <repository> delete_fork

--- a/README.md
+++ b/README.md
@@ -13,10 +13,6 @@ Further documentation is forthcoming.
 
 ***Make sure you installed everything here correclty, along with the others subsystems per instructions at https://github.com/turbo-src/turbo-src.***
 
-```
-./tsrc-dev start
-```
-
 Start turbosrc.
 
 ```
@@ -35,7 +31,7 @@ Restart turbosrc.
 ./tsrc-dev restart
 ```
 
-Test.
+Test turbosrc
 
 ```
 ./tsrc-dev test <username> <repository> execute_all
@@ -73,6 +69,10 @@ Here is a sample below for more granular control over testing.
 
 ```
 ./tsrc-dev test <username> <repository> create_pull_request
+````
+
+```
+./tsrc-dev test <username> <repository> run_tests
 ````
 
 ## Install

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -1,69 +1,80 @@
-##docker build -t turbo-src-server:0.0.1 -f docker/dockerfile.server .
-##docker-compose -f docker/docker-compose.yml up -d
-## Copy overwrite .config to where it's needed.
-## Can't reach file outside of testing dir
-## for some reason.
-\cp .config.json testing/integration/privaterepo/
+#!/bin/bash
 
-# Delete fork of demo.
-docker run -it \
-gihtub-maker-tools \
--d -r demo
+function delete_fork() {
+  REPO=$1
+  docker run -it gihtub-maker-tools -d -r $REPO
+}
 
-# Fork the demo.
-docker run -it fork-repo node fork-repo.js "turbo-src/demo"
+function fork_repo() {
+  REPO=$1
+  docker run -it fork-repo node fork-repo.js "turbo-src/$REPO"
+}
 
-sleep 5
+function create_pull_request() {
+  REPO=$1
+  docker run -it create-pull-requests python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest1" "refactor(lsp): remove redundant client cleanup" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest2" "refactor(uncrustify): set maximum number of consecutive newlines" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest3" "ci(mingw): only enable -municode for MinGW" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest4" "docs: add missing termdebug docs from Vim runtime updates" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest5" "refactor: missing parenthesis may cause unexpected problems" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest6" "refactor(normal): convert function comments to doxygen format" "auto pull request"
+}
 
-# Create pull requests.
-# docker run -it create-pull-request python create_pull_request.py owner repo base head title body
+function run_tests() {
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/createUser.js && sleep 5
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/createUser.js && sleep 5
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/createRepo.js && sleep 5
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/transferTokens.js && sleep 5
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/twoVoters.js && sleep 5
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/singleMajorityVoter.js && sleep 5
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/duplicateVote.js && sleep 5
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/manyVoters.js && sleep 5
+  npm test --prefix turbosrc-service/ testing/integration/privaterepo/semiAutoManyVoters.js && sleep 5
+}
 
-docker run -it create-pull-requests \
-python create_pull_requests.py "7db9a" "demo" "master" "pullRequest1" "refactor(lsp): remove redundant client cleanup" "auto pull request"
+function execute_all_except_tests() {
+  delete_fork $REPO
+  fork_repo $REPO
+  create_pull_request $REPO
+}
 
-docker run -it create-pull-requests \
-python create_pull_requests.py "7db9a" "demo" "master" "pullRequest2" "refactor(uncrustify): set maximum number of consecutive newlines" "auto pull request"
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <username> <repository> [delete_fork|fork_repo|create_pull_request|run_tests|execute_all|execute_all_except_tests]"
+  exit 1
+fi
 
-docker run -it create-pull-requests \
-python create_pull_requests.py "7db9a" "demo" "master" "pullRequest3" "ci(mingw): only enable -municode for MinGW" "auto pull request"
+USERNAME=$1
+REPO=$2
 
-
-docker run -it create-pull-requests \
-python create_pull_requests.py "7db9a" "demo" "master" "pullRequest4" "docs: add missing termdebug docs from Vim runtime updates" "auto pull request"
-
-docker run -it create-pull-requests \
-python create_pull_requests.py "7db9a" "demo" "master" "pullRequest5" "refactor: missing parenthesis may cause unexpected problems" "auto pull request"
-
-
-docker run -it create-pull-requests \
-python create_pull_requests.py "7db9a" "demo" "master" "pullRequest6" "refactor(normal): convert function comments to doxygen format" "auto pull request"
-
-sleep 5
-
-npm test testing/integration/privaterepo/createUser.js
-sleep 5
-npm test testing/integration/privaterepo/createRepo.js
-sleep 5
-npm test testing/integration/privaterepo/transferTokens.js
-sleep 5
-npm test testing/integration/privaterepo/twoVoters.js
-sleep 5
-npm test testing/integration/privaterepo/singleMajorityVoter.js
-sleep 5
-npm test testing/integration/privaterepo/duplicateVote.js
-sleep 5
-npm test testing/integration/privaterepo/manyVoters.js
-sleep 5
-npm test testing/integration/privaterepo/semiAutoManyVoters.js
-sleep 5
-
-echo "Please go to your browser and naviagate to the demo page in your github."
-echo "Then please vote on pull request #6 to merge or close it."
-
-
-#echo ""
-#echo "Please run"
-#echo ""
-#echo "docker-compose -f docker/docker-compose.yml down"
-#echo ""
-#echo "When finished"
+case "$3" in
+  "delete_fork")
+    delete_fork $REPO
+    ;;
+  "fork_repo")
+    fork_repo $REPO
+    ;;
+  "create_pull_request")
+    create_pull_request $REPO
+    ;;
+  "run_tests")
+    run_tests
+    ;;
+  "execute_all")
+    delete_fork $REPO
+    fork_repo $REPO
+    create_pull_request $REPO
+    run_tests
+    ;;
+  "execute_all_except_tests")
+    execute_all_except_tests
+    ;;
+  *)
+    echo "Usage: $0 <username> <repository> [delete_fork|fork_repo|create_pull_request|run_tests|execute_all|execute_all_except_tests]"
+    exit 1
+    ;;
+esac

--- a/tsrc-dev
+++ b/tsrc-dev
@@ -31,7 +31,7 @@ start_services() {
 
 run_tests() {
   if [[ $# -ne 3 ]]; then
-    echo "Usage: $0 test <username> <repository> <action>"
+    echo "Usage: $0 <username> <repository> [delete_fork|fork_repo|create_pull_request|run_tests|execute_all|execute_all_except_tests]"
     exit 1
   fi
 

--- a/tsrc-dev
+++ b/tsrc-dev
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 usage() {
-  echo "Usage: $0 [start|stop|restart|test]"
+  echo "Usage: $0 [start|stop|restart|test [USERNAME REPO ACTION]]"
+  echo "  test: $0 <username> <repository> [delete_fork|fork_repo|create_pull_request|run_tests|execute_all|execute_all_except_tests]"
   exit 1
 }
 
@@ -29,11 +30,19 @@ start_services() {
 }
 
 run_tests() {
-  echo "Running tests..."
-  scripts/tests.sh
+  if [[ $# -ne 3 ]]; then
+    echo "Usage: $0 test <username> <repository> <action>"
+    exit 1
+  fi
+
+  USERNAME=$1
+  REPO=$2
+  ACTION=$3
+
+  ./tsrc-test $USERNAME $REPO $ACTION
 }
 
-if [[ $# -ne 1 ]]; then
+if [[ $# -lt 1 ]]; then
   usage
 fi
 
@@ -45,7 +54,8 @@ elif [[ "$1" == "restart" ]]; then
   stop_services
   start_services
 elif [[ "$1" == "test" ]]; then
-  run_tests
+  shift
+  run_tests "$@"
 else
   usage
 fi

--- a/tsrc-test
+++ b/tsrc-test
@@ -11,6 +11,9 @@ function fork_repo() {
 }
 
 function create_pull_request() {
+  echo ""
+  echo "Creating pull requests..."
+  echo "" && sleep 1
   REPO=$1
   docker run -it create-pull-requests python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest1" "refactor(lsp): remove redundant client cleanup" "auto pull request"
   docker run -it create-pull-requests \
@@ -29,6 +32,9 @@ function run_tests() {
   # If we want to run from another director you can do for example
   # npm test --prefix turbosrc-service/ testing/integration/privaterepo/createUser.js
 
+  echo ""
+  echo "Running tests..."
+  echo "" && sleep 1
   npm test testing/integration/privaterepo/createUser.js && sleep 5
   npm test testing/integration/privaterepo/createUser.js && sleep 5
   npm test testing/integration/privaterepo/createRepo.js && sleep 5

--- a/tsrc-test
+++ b/tsrc-test
@@ -14,18 +14,19 @@ function create_pull_request() {
   echo ""
   echo "Creating pull requests..."
   echo "" && sleep 1
-  REPO=$1
-  docker run -it create-pull-requests python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest1" "refactor(lsp): remove redundant client cleanup" "auto pull request"
+  USERNAME=$1
+  REPO=$2
+  docker run -it create-pull-requests python create_pull_requests.py "$USERNAME" "$REPO" "master" "pullRequest1" "refactor(lsp): remove redundant client cleanup" "auto pull request"
   docker run -it create-pull-requests \
-  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest2" "refactor(uncrustify): set maximum number of consecutive newlines" "auto pull request"
+  python create_pull_requests.py "$USERNAME" "$REPO" "master" "pullRequest2" "refactor(uncrustify): set maximum number of consecutive newlines" "auto pull request"
   docker run -it create-pull-requests \
-  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest3" "ci(mingw): only enable -municode for MinGW" "auto pull request"
+  python create_pull_requests.py "$USERNAME" "$REPO" "master" "pullRequest3" "ci(mingw): only enable -municode for MinGW" "auto pull request"
   docker run -it create-pull-requests \
-  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest4" "docs: add missing termdebug docs from Vim runtime updates" "auto pull request"
+  python create_pull_requests.py "$USERNAME" "$REPO" "master" "pullRequest4" "docs: add missing termdebug docs from Vim runtime updates" "auto pull request"
   docker run -it create-pull-requests \
-  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest5" "refactor: missing parenthesis may cause unexpected problems" "auto pull request"
+  python create_pull_requests.py "$USERNAME" "$REPO" "master" "pullRequest5" "refactor: missing parenthesis may cause unexpected problems" "auto pull request"
   docker run -it create-pull-requests \
-  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest6" "refactor(normal): convert function comments to doxygen format" "auto pull request"
+  python create_pull_requests.py "$USERNAME" "$REPO" "master" "pullRequest6" "refactor(normal): convert function comments to doxygen format" "auto pull request"
 }
 
 function run_tests() {
@@ -49,7 +50,7 @@ function run_tests() {
 function execute_all_except_tests() {
   delete_fork $REPO
   fork_repo $REPO
-  create_pull_request $REPO
+  create_pull_request $USERNAME $REPO
 }
 
 if [ $# -lt 2 ]; then
@@ -68,7 +69,7 @@ case "$3" in
     fork_repo $REPO
     ;;
   "create_pull_request")
-    create_pull_request $REPO
+    create_pull_request $USERNAME $REPO
     ;;
   "run_tests")
     run_tests
@@ -76,7 +77,7 @@ case "$3" in
   "execute_all")
     delete_fork $REPO
     fork_repo $REPO
-    create_pull_request $REPO
+    create_pull_request $USERNAME $REPO
     run_tests
     ;;
   "execute_all_except_tests")

--- a/tsrc-test
+++ b/tsrc-test
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+function delete_fork() {
+  REPO=$1
+  docker run -it gihtub-maker-tools -d -r $REPO
+}
+
+function fork_repo() {
+  REPO=$1
+  docker run -it fork-repo node fork-repo.js "turbo-src/$REPO"
+}
+
+function create_pull_request() {
+  REPO=$1
+  docker run -it create-pull-requests python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest1" "refactor(lsp): remove redundant client cleanup" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest2" "refactor(uncrustify): set maximum number of consecutive newlines" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest3" "ci(mingw): only enable -municode for MinGW" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest4" "docs: add missing termdebug docs from Vim runtime updates" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest5" "refactor: missing parenthesis may cause unexpected problems" "auto pull request"
+  docker run -it create-pull-requests \
+  python create_pull_requests.py "7db9a" "$REPO" "master" "pullRequest6" "refactor(normal): convert function comments to doxygen format" "auto pull request"
+}
+
+function run_tests() {
+  # If we want to run from another director you can do for example
+  # npm test --prefix turbosrc-service/ testing/integration/privaterepo/createUser.js
+
+  npm test testing/integration/privaterepo/createUser.js && sleep 5
+  npm test testing/integration/privaterepo/createUser.js && sleep 5
+  npm test testing/integration/privaterepo/createRepo.js && sleep 5
+  npm test testing/integration/privaterepo/transferTokens.js && sleep 5
+  npm test testing/integration/privaterepo/twoVoters.js && sleep 5
+  npm test testing/integration/privaterepo/singleMajorityVoter.js && sleep 5
+  npm test testing/integration/privaterepo/duplicateVote.js && sleep 5
+  npm test testing/integration/privaterepo/manyVoters.js && sleep 5
+  npm test testing/integration/privaterepo/semiAutoManyVoters.js && sleep 5
+}
+
+function execute_all_except_tests() {
+  delete_fork $REPO
+  fork_repo $REPO
+  create_pull_request $REPO
+}
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <username> <repository> [delete_fork|fork_repo|create_pull_request|run_tests|execute_all|execute_all_except_tests]"
+  exit 1
+fi
+
+USERNAME=$1
+REPO=$2
+
+case "$3" in
+  "delete_fork")
+    delete_fork $REPO
+    ;;
+  "fork_repo")
+    fork_repo $REPO
+    ;;
+  "create_pull_request")
+    create_pull_request $REPO
+    ;;
+  "run_tests")
+    run_tests
+    ;;
+  "execute_all")
+    delete_fork $REPO
+    fork_repo $REPO
+    create_pull_request $REPO
+    run_tests
+    ;;
+  "execute_all_except_tests")
+    execute_all_except_tests
+    ;;
+  *)
+    echo "Usage: $0 <username> <repository> [delete_fork|fork_repo|create_pull_request|run_tests|execute_all|execute_all_except_tests]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Most important update is that a developer can now run tests without modifying the script. Before they had to modify with their gh username in the section where it created test pull requests. No more.

Just run this to run tests (including, forking, etc).
`./tsrc-dev test <username> <repository> execute_all`

See updated README for further usage.

Here are some other changes:

- Total refactor: test-dev now is modular and everything is functions.
-  Proper command line bash script with arguments and subcommands.
- New subcommand `test-dev test`