### PR TITLE
fix: getPR was null when merging was live due to unexpected behavior …

### DIFF
--- a/src/lib/actions.js
+++ b/src/lib/actions.js
@@ -325,7 +325,7 @@ const root = {
 
     console.log('getPR', status)
 
-    status.mergeableCodeHost = mergeableCodeHost
+    status.mergeableCodeHost = mergeableCodeHost || true
    
     return status;
   },


### PR DESCRIPTION
…when a PR is actually merged on GitHub, causing front end to fail